### PR TITLE
added env var COMMAND_LINE

### DIFF
--- a/scripts/wiki_data.py
+++ b/scripts/wiki_data.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 
 from wikichat import cli
@@ -48,7 +49,9 @@ if __name__ == "__main__":
     _config_logging()
     parser = cli.config_arg_parse()
 
-    args = parser.parse_args()
+    env_cmd = os.getenv("COMMAND_LINE")
+    cmds = env_cmd.split(" ") if env_cmd else None
+    args = parser.parse_args(args=cmds)
 
     if not hasattr(args, "command_def"):
         parser.print_help()


### PR DESCRIPTION
if set, this is parsed as the command line. useful at heroku

e.g.

(.venv) aaron.morton@Aaron-Morton-VX2KC4KLHW wikichat % python3 scripts/wiki_data.py suggested-search --repeats=1000 (.venv) aaron.morton@Aaron-Morton-VX2KC4KLHW wikichat % export COMMAND_LINE="suggested-search --repeats=1000" (.venv) aaron.morton@Aaron-Morton-VX2KC4KLHW wikichat % python3 scripts/wiki_data.py
2024-01-16 16:45:16.435 - INFO    - root - unknown_worker - Running command suggested-search with args SuggestedSearchArgs(repeats=1000, limit=5, delay_secs=2)